### PR TITLE
Docker for testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ADD tests ./tests
 
 ADD setup.py ./
 
-RUN python setup.py build
+RUN python setup.py pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.9.16-alpine3.17
+
+RUN  mkdir -p /workspace/python-lambda-powertools
+
+WORKDIR /workspace/python-lambda-powertools
+
+COPY requirements-tests.txt ./
+RUN pip --no-cache-dir install -r ./requirements-tests.txt
+
+COPY lambda_powertools lambda_powertools
+RUN mkdir -p tests
+COPY tests/*.py tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ RUN  mkdir -p /workspace/python-lambda-powertools
 
 WORKDIR /workspace/python-lambda-powertools
 
-COPY requirements-tests.txt ./
-RUN pip --no-cache-dir install -r ./requirements-tests.txt
+ADD lambda_powertools ./lambda_powertools
+ADD tests ./tests
 
-COPY lambda_powertools lambda_powertools
-RUN mkdir -p tests
-COPY tests/*.py tests/
+ADD setup.py ./
+
+RUN python setup.py build

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker compose up --build
 
 ## Releasing
 
-To install the package locally, for inter-project usage, run:
+To install the package locally, for inter-project usage, set the proper version in the file path and run:
 
 ```bash
 python setup.py bdist_wheel

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Lambda Powertools is a package encapsulating utilities and best practices used to write Python Lambda functions at Spreaker.
 
+## Local development
+To develop locally the library spin on the necessary container:
+
+```
+docker compose up --build
+```
+
+Enter the dev container and run the tests with `pytest`:
+
+```
+docker compose exec dev sh
+```
+
 ## Components
 
 ### PowerHandler

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Lambda Powertools is a package encapsulating utilities and best practices used t
 
 ## Local development
 
-To develop locally the library build the necessary container with, pytest will run automatically:
+To develop locally the library build the container, pytest will run automatically:
 
 ```bash
 docker compose up --build

--- a/README.md
+++ b/README.md
@@ -3,16 +3,29 @@
 Lambda Powertools is a package encapsulating utilities and best practices used to write Python Lambda functions at Spreaker.
 
 ## Local development
-To develop locally the library spin on the necessary container:
 
-```
+To develop locally the library spin on the necessary container and run it:
+
+```bash
 docker compose up --build
-```
 
-Enter the dev container and run the tests with `pytest`:
-
-```
 docker compose exec dev sh
+```
+
+Then you can run the tests with:
+
+```bash
+python setup.py pytest
+```
+
+## Releasing
+
+To install the package locally, for inter-project usage, run:
+
+```bash
+python setup.py bdist_wheel
+
+pip install ./dist/lambda_powertools-0.1.0-py3-none-any.whl --force-reinstall
 ```
 
 ## Components

--- a/README.md
+++ b/README.md
@@ -4,18 +4,10 @@ Lambda Powertools is a package encapsulating utilities and best practices used t
 
 ## Local development
 
-To develop locally the library spin on the necessary container and run it:
+To develop locally the library build the necessary container with, pytest will run automatically:
 
 ```bash
 docker compose up --build
-
-docker compose exec dev sh
-```
-
-Then you can run the tests with:
-
-```bash
-python setup.py pytest
 ```
 
 ## Releasing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+
+services:
+  dev:
+    build:
+      context:    .
+      dockerfile: Dockerfile
+    command: [ "sh" ]

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,2 @@
+pytest==7.2.2
+pytest-mock==3.10.0

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,2 +1,0 @@
-pytest==7.2.2
-pytest-mock==3.10.0


### PR DESCRIPTION
I'm adding the needed for local testing, to avoid the usage of virtual environments or worse installing dependencies locally.
Being all the requirements already specified in the `setup.py`, I didn't add a requirements.txt file to avoid redundancy. Building the container check the requirements and run the tests automatically.